### PR TITLE
GuzzleHttp支持7.*和6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
         }
     ],
     "require": {
-        "php": ">= 7.0",
+        "php": ">=7.0",
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-SimpleXML": "*",
         "ext-mbstring": "*",
         "ext-libxml": "*",
-        "guzzlehttp/guzzle": "^6.5"
+        "guzzlehttp/guzzle": "^7.3|^6.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.2"


### PR DESCRIPTION
这个变更将支持仓库在Laravel8项目中使用